### PR TITLE
update egui to 19.0, replace glutin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,16 +100,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_glue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
-
-[[package]]
 name = "anyhow"
 version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+
+[[package]]
+name = "arboard"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc120354d1b5ec6d7aaf4876b602def75595937b5e15d356eb554ab5177e08bb"
+dependencies = [
+ "clipboard-win 4.4.2",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "parking_lot 0.12.1",
+ "thiserror",
+ "winapi",
+ "x11rb",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -411,6 +446,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "calloop"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22a6a8f622f797120d452c630b0ab12e1331a1a753e2039ce7868d4ac77b4ee"
+dependencies = [
+ "log",
+ "nix 0.24.2",
+ "slotmap",
+ "thiserror",
+ "vec_map",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +546,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,7 +576,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation 0.9.3",
  "core-graphics 0.22.3",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -523,7 +591,7 @@ dependencies = [
  "block",
  "core-foundation 0.9.3",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -575,7 +643,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4423d79fed83ebd9ab81ec21fa97144300a961782158287dc9bf7eddac37ff0b"
 dependencies = [
- "clipboard-win",
+ "clipboard-win 3.1.1",
  "objc",
  "objc-foundation",
  "objc_id",
@@ -623,7 +691,7 @@ checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
 dependencies = [
  "bitflags",
  "core-foundation 0.7.0",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -636,7 +704,7 @@ dependencies = [
  "bitflags",
  "core-foundation 0.9.3",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -648,7 +716,19 @@ checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
  "core-foundation 0.9.3",
- "foreign-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "19.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+dependencies = [
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -878,6 +958,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossfont"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66b1c1979c4362323f03ab6bf7fb522902bfc418e0c37319ab347f9561d980f"
+dependencies = [
+ "cocoa",
+ "core-foundation 0.9.3",
+ "core-foundation-sys 0.8.3",
+ "core-graphics 0.22.3",
+ "core-text",
+ "dwrote",
+ "foreign-types 0.5.0",
+ "freetype-rs",
+ "libc",
+ "log",
+ "objc",
+ "once_cell",
+ "pkg-config",
+ "servo-fontconfig",
+ "winapi",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,7 +1009,7 @@ dependencies = [
  "objc",
  "rust-ini",
  "web-sys",
- "winreg 0.8.0",
+ "winreg",
  "zbus",
  "zvariant",
 ]
@@ -1070,6 +1173,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dwrote"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_derive",
+ "winapi",
+ "wio",
+]
+
+[[package]]
+name = "eframe"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d49426c3e72a6728b0c790d22db8bf7bbcff10d83b8b6f3a01295be982302e"
+dependencies = [
+ "bytemuck",
+ "egui 0.19.0",
+ "egui-winit 0.19.0",
+ "egui_glow",
+ "getrandom",
+ "glow",
+ "glutin",
+ "js-sys",
+ "percent-encoding",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winit 0.27.2",
+]
+
+[[package]]
 name = "egui"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,12 +1222,12 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb095a8b9feb9b7ff8f00b6776dffcef059538a3f4a91238e03c900e9c9ad9a2"
+checksum = "fc9fcd393c3daaaf5909008a1d948319d538b79c51871e4df0993260260a94e4"
 dependencies = [
- "ahash 0.7.6",
- "epaint 0.18.1",
+ "ahash 0.8.0",
+ "epaint 0.19.0",
  "nohash-hasher",
  "tracing",
 ]
@@ -1104,31 +1243,33 @@ dependencies = [
  "egui 0.17.0",
  "instant",
  "tracing",
- "webbrowser",
- "winit",
+ "webbrowser 0.6.0",
+ "winit 0.26.1",
 ]
 
 [[package]]
 name = "egui-winit"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b040afd583fd95a9b9578d4399214a13d948ed26bc0ff7cc0104502501f34e68"
+checksum = "07ddc525334c416e11580123e147b970f738507f427c9fb1cd09ea2dd7416a3a"
 dependencies = [
- "egui 0.18.1",
+ "arboard",
+ "egui 0.19.0",
  "instant",
+ "smithay-clipboard",
  "tracing",
- "winit",
+ "webbrowser 0.7.1",
+ "winit 0.27.2",
 ]
 
 [[package]]
 name = "egui_glow"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43ed7ec7199907ab5853c3bb3883ae1e741ab540aa127a798a60b7bdb906f1"
+checksum = "ad77d4a00402bae9658ee64be148f4b2a0b38e4fc7874970575ca01ed1c5b75d"
 dependencies = [
  "bytemuck",
- "egui 0.18.1",
- "egui-winit 0.18.0",
+ "egui 0.19.0",
  "glow",
  "memoffset",
  "tracing",
@@ -1164,24 +1305,11 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c223f58c7e38abe1770f367b969f1b3fbd4704b67666bcb65dbb1adb0980ba72"
+checksum = "9542a40106fdba943a055f418d1746a050e1a903a049b030c2b097d4686a33cf"
 dependencies = [
  "bytemuck",
-]
-
-[[package]]
-name = "embed-resource"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc24ff8d764818e9ab17963b0593c535f077a513f565e75e4352d758bc4d8c0"
-dependencies = [
- "cc",
- "rustc_version",
- "toml",
- "vswhom",
- "winreg 0.10.1",
 ]
 
 [[package]]
@@ -1234,15 +1362,15 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c29567088888e8ac3e8f61bbb2ddc820207ebb8d69eefde5bcefa06d65e4e89"
+checksum = "5ba04741be7f6602b1a1b28f1082cce45948a7032961c52814f8946b28493300"
 dependencies = [
  "ab_glyph",
- "ahash 0.7.6",
+ "ahash 0.8.0",
  "atomic_refcell",
  "bytemuck",
- "emath 0.18.0",
+ "emath 0.19.0",
  "nohash-hasher",
  "parking_lot 0.12.1",
 ]
@@ -1269,10 +1397,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "expat-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+dependencies = [
+ "cmake",
+ "pkg-config",
+]
 
 [[package]]
 name = "exr"
@@ -1371,7 +1519,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1381,6 +1550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1563,28 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "freetype-rs"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb"
+dependencies = [
+ "bitflags",
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1456,7 +1653,7 @@ dependencies = [
 name = "gamercade_audio"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "hound",
  "rodio",
  "rtrb",
@@ -1487,7 +1684,7 @@ dependencies = [
  "serde",
  "strum",
  "wasmtime",
- "winit",
+ "winit 0.26.1",
  "winit_input_helper",
  "zstd",
 ]
@@ -1507,11 +1704,9 @@ name = "gamercade_editor"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "egui 0.18.1",
- "egui_glow",
+ "eframe",
  "gamercade_audio",
  "gamercade_core",
- "glutin",
  "hashbrown 0.12.3",
  "image",
  "rfd",
@@ -1575,6 +1770,16 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1681,29 +1886,28 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ea9dbe544bc8a657c4c4a798c2d16cd01b549820e47657297549d28371f6d2"
+checksum = "444c9ad294fdcaf20ccf6726b78f380b5450275540c9b68ab62f49726ad1c713"
 dependencies = [
- "android_glue",
  "cgl",
  "cocoa",
  "core-foundation 0.9.3",
  "glutin_egl_sys",
- "glutin_emscripten_sys",
  "glutin_gles2_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
- "lazy_static",
  "libloading",
  "log",
  "objc",
+ "once_cell",
  "osmesa-sys",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
+ "raw-window-handle 0.5.0",
  "wayland-client",
  "wayland-egl",
  "winapi",
- "winit",
+ "winit 0.27.2",
 ]
 
 [[package]]
@@ -1715,12 +1919,6 @@ dependencies = [
  "gl_generator",
  "winapi",
 ]
-
-[[package]]
-name = "glutin_emscripten_sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80de4146df76e8a6c32b03007bc764ff3249dcaeb4f675d68a06caf1bac363f1"
 
 [[package]]
 name = "glutin_gles2_sys"
@@ -2206,7 +2404,7 @@ dependencies = [
  "bitflags",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "log",
  "objc",
 ]
@@ -2318,6 +2516,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
+dependencies = [
+ "bitflags",
+ "jni-sys",
+ "ndk-sys 0.4.0",
+ "num_enum",
+ "raw-window-handle 0.5.0",
+ "thiserror",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2566,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-glue"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0434fabdd2c15e0aab768ca31d5b7b333717f03cf02037d5a0a3ff3c278ed67f"
+dependencies = [
+ "libc",
+ "log",
+ "ndk 0.7.0",
+ "ndk-context",
+ "ndk-macro",
+ "ndk-sys 0.4.0",
+ "once_cell",
+ "parking_lot 0.12.1",
+]
+
+[[package]]
 name = "ndk-macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2605,15 @@ name = "ndk-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d83ec9c63ec5bf950200a8e508bdad6659972187b625469f58ef8c08e29046"
 dependencies = [
  "jni-sys",
 ]
@@ -2416,6 +2653,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2772,7 +3010,7 @@ checksum = "a3be4951b24b374c72b0aaaeb59e51e1acb38b8e680b11f43c1d0049b8550891"
 dependencies = [
  "bytemuck",
  "pollster",
- "raw-window-handle",
+ "raw-window-handle 0.4.3",
  "thiserror",
  "ultraviolet",
  "wgpu",
@@ -2921,6 +3159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7e3d950b66e19e0c372f3fa3fbbcf85b1746b571f74e0c2af6042a5c93420a"
+dependencies = [
+ "cty",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,13 +3269,12 @@ checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
 
 [[package]]
 name = "rfd"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f121348fd3b9035ed11be1f028e8944263c30641f8c5deacf57a4320782fb402"
+checksum = "0149778bd99b6959285b0933288206090c50e2327f47a9c463bfdbf45c8823ea"
 dependencies = [
  "block",
  "dispatch",
- "embed-resource",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
@@ -3038,7 +3284,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "raw-window-handle",
+ "raw-window-handle 0.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3088,15 +3334,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -3161,10 +3398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "1.0.13"
+name = "sctk-adwaita"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "04b7c47a572f73de28bee5b5060d085b42b6ce1e4ee2b49c956ea7b25e94b6f0"
+dependencies = [
+ "crossfont",
+ "log",
+ "smithay-client-toolkit 0.16.0",
+ "tiny-skia",
+]
 
 [[package]]
 name = "serde"
@@ -3215,6 +3458,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "servo-fontconfig"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c"
+dependencies = [
+ "libc",
+ "servo-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
+dependencies = [
+ "expat-sys",
+ "freetype-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3309,7 +3573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3"
 dependencies = [
  "bitflags",
- "calloop",
+ "calloop 0.9.3",
  "dlib",
  "lazy_static",
  "log",
@@ -3328,6 +3592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
  "bitflags",
+ "calloop 0.10.1",
  "dlib",
  "lazy_static",
  "log",
@@ -3405,6 +3670,12 @@ name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
@@ -3537,6 +3808,31 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642680569bb895b16e4b9d181c60be1ed136fa0c9c7f11d004daf053ba89bf82"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "bytemuck",
+ "cfg-if 1.0.0",
+ "png",
+ "safe_arch",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c114d32f0c2ee43d585367cb013dfaba967ab9f62b90d9af0d696e955e70fa6c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
 ]
 
 [[package]]
@@ -3687,6 +3983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ea29db9f94ff08bb619656b8120878f280526f71dc88b5262c958a510181812"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version-compare"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3697,26 +3999,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vswhom"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
-dependencies = [
- "libc",
- "vswhom-sys",
-]
-
-[[package]]
-name = "vswhom-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22025f6d8eb903ebf920ea6933b70b1e495be37e2cb4099e62c80454aaf57c39"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "waker-fn"
@@ -4139,6 +4421,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a3cffdb686fbb24d9fb8f03a213803277ed2300f11026a3afe1f108dc021b"
+dependencies = [
+ "jni",
+ "ndk-glue 0.6.2",
+ "url",
+ "web-sys",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4159,12 +4455,12 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "js-sys",
  "log",
  "naga",
  "parking_lot 0.11.2",
- "raw-window-handle",
+ "raw-window-handle 0.4.3",
  "smallvec",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4180,7 +4476,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "bitflags",
  "cfg_aliases",
  "codespan-reporting",
@@ -4190,7 +4486,7 @@ dependencies = [
  "naga",
  "parking_lot 0.11.2",
  "profiling",
- "raw-window-handle",
+ "raw-window-handle 0.4.3",
  "smallvec",
  "thiserror",
  "wgpu-hal",
@@ -4203,14 +4499,14 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.2",
  "ash",
  "bit-set",
  "bitflags",
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types",
+ "foreign-types 0.3.2",
  "fxhash",
  "glow",
  "gpu-alloc",
@@ -4226,7 +4522,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "profiling",
  "range-alloc",
- "raw-window-handle",
+ "raw-window-handle 0.4.3",
  "renderdoc-sys",
  "thiserror",
  "wasm-bindgen",
@@ -4281,6 +4577,15 @@ name = "winapi-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-wsapoll"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
 dependencies = [
  "winapi",
 ]
@@ -4400,7 +4705,7 @@ dependencies = [
  "objc",
  "parking_lot 0.11.2",
  "percent-encoding",
- "raw-window-handle",
+ "raw-window-handle 0.4.3",
  "smithay-client-toolkit 0.15.4",
  "wasm-bindgen",
  "wayland-client",
@@ -4411,12 +4716,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "winit"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a8f3e9d742401efcfe833b8f84960397482ff049cb7bf59a112e14a4be97f7"
+dependencies = [
+ "bitflags",
+ "cocoa",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
+ "dispatch",
+ "instant",
+ "libc",
+ "log",
+ "mio",
+ "ndk 0.7.0",
+ "ndk-glue 0.7.0",
+ "objc",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "raw-window-handle 0.4.3",
+ "raw-window-handle 0.5.0",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.16.0",
+ "wasm-bindgen",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "windows-sys",
+ "x11-dl",
+]
+
+[[package]]
 name = "winit_input_helper"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f114b4fe1f38c80027543eb8a0711634fb9136a5cd18e8e990122aaea21f9302"
 dependencies = [
- "winit",
+ "winit 0.26.1",
 ]
 
 [[package]]
@@ -4429,10 +4767,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.10.1"
+name = "wio"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 dependencies = [
  "winapi",
 ]
@@ -4455,6 +4793,18 @@ dependencies = [
  "lazy_static",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e99be55648b3ae2a52342f9a870c0e138709a3493261ce9b469afe6e4df6d8a"
+dependencies = [
+ "gethostname",
+ "nix 0.22.3",
+ "winapi",
+ "winapi-wsapoll",
 ]
 
 [[package]]

--- a/gamercade_console/Cargo.toml
+++ b/gamercade_console/Cargo.toml
@@ -47,4 +47,4 @@ fastrand = "1.8.0"
 ggrs = "0.9.2"
 
 # File Picker Dialog
-rfd = "0.9.1"
+rfd = "0.10.0"

--- a/gamercade_editor/Cargo.toml
+++ b/gamercade_editor/Cargo.toml
@@ -17,15 +17,13 @@ serde_json = "1.0.85"
 zstd = "0.11"
 
 # Window and Rendering
-egui_glow = { version = "0.18.1", features = ["winit"] }
-egui = "0.18.1"
-glutin = "0.28.0"
+eframe = "0.19.0"
 
 # File Dialogs
-rfd = "0.9.1"
+rfd = "0.10.0"
 
 # Image Manipulation
-image = "0.24.2"
+image = "0.24.3"
 
 # General Improvements
 hashbrown = "0.12.3"

--- a/gamercade_editor/src/main.rs
+++ b/gamercade_editor/src/main.rs
@@ -1,117 +1,19 @@
-use egui_glow::{self, glow, painter::TextureFilter};
+use eframe::epaint::Vec2;
+use ui::Editor;
 
 mod editor_data;
 mod ui;
 
-use crate::ui::Editor;
-
 fn main() {
-    let clear_color = [0.1, 0.1, 0.1];
-
-    let mut editor = Editor::default();
-
-    let event_loop = glutin::event_loop::EventLoop::with_user_event();
-    let (gl_window, gl) = create_display(&event_loop);
-    let gl = std::rc::Rc::new(gl);
-
-    let mut egui_glow = egui_glow::EguiGlow::new(gl_window.window(), gl.clone());
-    egui_glow.painter.set_texture_filter(TextureFilter::Nearest);
-
-    event_loop.run(move |event, _, control_flow| {
-        let mut redraw = || {
-            let needs_repaint = egui_glow.run(gl_window.window(), |egui_ctx| {
-                editor.draw_menu_panel(egui_ctx);
-                editor.draw_bottom_panel(egui_ctx);
-                editor.draw_central_panel(egui_ctx);
-            });
-
-            if needs_repaint {
-                gl_window.window().request_redraw();
-                glutin::event_loop::ControlFlow::Poll
-            } else {
-                glutin::event_loop::ControlFlow::Wait
-            };
-
-            {
-                unsafe {
-                    use egui_glow::glow::HasContext as _;
-                    gl.clear_color(clear_color[0], clear_color[1], clear_color[2], 1.0);
-                    gl.clear(glow::COLOR_BUFFER_BIT);
-                }
-
-                // draw things behind egui here
-
-                egui_glow.paint(gl_window.window());
-
-                // draw things on top of egui here
-
-                gl_window.swap_buffers().unwrap();
-            }
-        };
-
-        match event {
-            // Platform-dependent event handlers to workaround a winit bug
-            // See: https://github.com/rust-windowing/winit/issues/987
-            // See: https://github.com/rust-windowing/winit/issues/1619
-            glutin::event::Event::RedrawEventsCleared if cfg!(windows) => redraw(),
-            glutin::event::Event::RedrawRequested(_) if !cfg!(windows) => redraw(),
-
-            glutin::event::Event::WindowEvent { event, .. } => {
-                use glutin::event::WindowEvent;
-                if matches!(event, WindowEvent::CloseRequested | WindowEvent::Destroyed) {
-                    *control_flow = glutin::event_loop::ControlFlow::Exit;
-                }
-
-                if let glutin::event::WindowEvent::Resized(physical_size) = &event {
-                    gl_window.resize(*physical_size);
-                } else if let glutin::event::WindowEvent::ScaleFactorChanged {
-                    new_inner_size,
-                    ..
-                } = &event
-                {
-                    gl_window.resize(**new_inner_size);
-                }
-
-                egui_glow.on_event(&event);
-
-                gl_window.window().request_redraw(); // TODO: ask egui if the events warrants a repaint instead
-            }
-            glutin::event::Event::LoopDestroyed => {
-                egui_glow.destroy();
-            }
-
-            _ => (),
-        }
-    });
-}
-
-fn create_display(
-    event_loop: &glutin::event_loop::EventLoop<()>,
-) -> (
-    glutin::WindowedContext<glutin::PossiblyCurrent>,
-    glow::Context,
-) {
-    let window_builder = glutin::window::WindowBuilder::new()
-        .with_resizable(true)
-        .with_inner_size(glutin::dpi::LogicalSize {
-            width: 1366.0,
-            height: 768.0,
-        })
-        .with_title("Gamercade Editor");
-
-    let gl_window = unsafe {
-        glutin::ContextBuilder::new()
-            .with_depth_buffer(0)
-            .with_srgb(true)
-            .with_stencil_buffer(0)
-            .with_vsync(true)
-            .build_windowed(window_builder, event_loop)
-            .unwrap()
-            .make_current()
-            .unwrap()
+    let options = eframe::NativeOptions {
+        vsync: true,
+        initial_window_size: Some(Vec2::new(1366.0, 768.0)),
+        ..Default::default()
     };
 
-    let gl = unsafe { glow::Context::from_loader_function(|s| gl_window.get_proc_address(s)) };
-
-    (gl_window, gl)
+    eframe::run_native(
+        "Gamercade Editor",
+        options,
+        Box::new(|_cc| Box::new(Editor::default())),
+    )
 }

--- a/gamercade_editor/src/ui/audio/audio_editor.rs
+++ b/gamercade_editor/src/ui/audio/audio_editor.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::Ui;
 
 use crate::editor_data::EditorSoundData;
 

--- a/gamercade_editor/src/ui/audio/chain_editor.rs
+++ b/gamercade_editor/src/ui/audio/chain_editor.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::Ui;
 
 #[derive(Clone, Debug, Default)]
 pub struct ChainEditor {}

--- a/gamercade_editor/src/ui/audio/instrument_editor.rs
+++ b/gamercade_editor/src/ui/audio/instrument_editor.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::Ui;
 
 #[derive(Clone, Debug, Default)]
 pub struct InstrumentEditor {}

--- a/gamercade_editor/src/ui/audio/pattern_editor.rs
+++ b/gamercade_editor/src/ui/audio/pattern_editor.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::Ui;
 
 #[derive(Clone, Debug, Default)]
 pub struct PatternEditor {}

--- a/gamercade_editor/src/ui/audio/song_editor.rs
+++ b/gamercade_editor/src/ui/audio/song_editor.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::Ui;
 
 #[derive(Clone, Debug, Default)]
 pub struct SongEditor {}

--- a/gamercade_editor/src/ui/editor.rs
+++ b/gamercade_editor/src/ui/editor.rs
@@ -1,6 +1,6 @@
 use std::{fs, io::Write, path::PathBuf};
 
-use egui::{self, menu, Context};
+use eframe::egui::{self, menu, Context};
 use rfd::FileDialog;
 
 use crate::editor_data::EditorRom;
@@ -35,6 +35,14 @@ impl Default for Editor {
             audio_editor: AudioEditor::default(),
             wasm_path: None,
         }
+    }
+}
+
+impl eframe::App for Editor {
+    fn update(&mut self, ctx: &eframe::egui::Context, _frame: &mut eframe::Frame) {
+        self.draw_menu_panel(ctx);
+        self.draw_bottom_panel(ctx);
+        self.draw_central_panel(ctx);
     }
 }
 

--- a/gamercade_editor/src/ui/graphics/graphics_editor.rs
+++ b/gamercade_editor/src/ui/graphics/graphics_editor.rs
@@ -1,4 +1,6 @@
-use egui::{Color32, ColorImage, Image, Slider, TextureHandle, TextureId, Ui, Vec2};
+use eframe::egui::{
+    Color32, ColorImage, Image, Slider, TextureFilter, TextureHandle, TextureId, Ui, Vec2,
+};
 
 use super::{PaletteEditor, SpriteEditor, SpriteSheetEditor};
 use crate::editor_data::EditorGraphicsData;
@@ -56,6 +58,7 @@ impl GraphicsEditor {
                 ui.ctx().load_texture(
                     "default palette texture",
                     ColorImage::from_rgba_unmultiplied([1, 1], &[255, 255, 255, 255]),
+                    TextureFilter::Nearest,
                 )
             })
             .id();

--- a/gamercade_editor/src/ui/graphics/mod.rs
+++ b/gamercade_editor/src/ui/graphics/mod.rs
@@ -3,6 +3,7 @@ mod palette_editor_tab;
 mod sprite_editor_tab;
 mod sprite_sheet_editor_tab;
 
+use eframe::egui::TextureFilter;
 pub use graphics_editor::*;
 pub use palette_editor_tab::*;
 pub use sprite_editor_tab::*;
@@ -63,18 +64,18 @@ pub(crate) fn import_many_images_dialog(title: &str) -> Result<Vec<image::RgbaIm
 }
 
 pub(crate) fn load_buffered_image<'a>(
-    ui: &mut egui::Ui,
-    handle: &'a mut Option<egui::TextureHandle>,
+    ui: &mut eframe::egui::Ui,
+    handle: &'a mut Option<eframe::egui::TextureHandle>,
     label: &'a str,
-    rgb: egui::ColorImage,
-) -> &'a egui::TextureHandle {
+    rgb: eframe::egui::ColorImage,
+) -> &'a eframe::egui::TextureHandle {
     match handle {
         Some(handle) => {
-            handle.set(rgb);
+            handle.set(rgb, TextureFilter::Nearest);
             handle
         }
         None => {
-            *handle = Some(ui.ctx().load_texture(label, rgb));
+            *handle = Some(ui.ctx().load_texture(label, rgb, TextureFilter::Nearest));
             handle.as_ref().unwrap()
         }
     }

--- a/gamercade_editor/src/ui/graphics/palette_editor_tab/color_editor.rs
+++ b/gamercade_editor/src/ui/graphics/palette_editor_tab/color_editor.rs
@@ -1,4 +1,4 @@
-use egui::{Checkbox, Color32, Image, Slider, TextureId, Ui, Vec2};
+use eframe::egui::{Checkbox, Color32, Image, Slider, TextureId, Ui, Vec2};
 use gamercade_core::Color;
 
 #[derive(Clone, Debug, Default)]

--- a/gamercade_editor/src/ui/graphics/palette_editor_tab/mod.rs
+++ b/gamercade_editor/src/ui/graphics/palette_editor_tab/mod.rs
@@ -11,7 +11,7 @@ use palette_viewer::PaletteViewer;
 use sprite_preview::SpritePreview;
 
 // Externals
-use egui::{SidePanel, TextureId, TopBottomPanel, Ui};
+use eframe::egui::{SidePanel, TextureId, TopBottomPanel, Ui};
 
 use super::SpriteSheetEditor;
 use crate::editor_data::EditorGraphicsData;

--- a/gamercade_editor/src/ui/graphics/palette_editor_tab/palette_list.rs
+++ b/gamercade_editor/src/ui/graphics/palette_editor_tab/palette_list.rs
@@ -1,4 +1,4 @@
-use egui::{ScrollArea, TextureId, Ui};
+use eframe::egui::{ScrollArea, TextureId, Ui};
 use hashbrown::HashSet;
 
 use crate::{

--- a/gamercade_editor/src/ui/graphics/palette_editor_tab/palette_viewer.rs
+++ b/gamercade_editor/src/ui/graphics/palette_editor_tab/palette_viewer.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, ImageButton, TextureId, Ui, Vec2};
+use eframe::egui::{Color32, ImageButton, TextureId, Ui, Vec2};
 use gamercade_core::{Color, Palette, PALETTE_COLORS};
 
 #[derive(Clone, Default, Debug)]

--- a/gamercade_editor/src/ui/graphics/palette_editor_tab/sprite_preview.rs
+++ b/gamercade_editor/src/ui/graphics/palette_editor_tab/sprite_preview.rs
@@ -1,4 +1,4 @@
-use egui::{ColorImage, Image, ScrollArea, TextureHandle, Ui, Vec2};
+use eframe::egui::{ColorImage, Image, ScrollArea, TextureHandle, Ui, Vec2};
 use gamercade_core::{ColorIndex, Palette, SpriteIndex, SpriteSheet};
 
 use crate::ui::load_buffered_image;

--- a/gamercade_editor/src/ui/graphics/sprite_editor_tab/mod.rs
+++ b/gamercade_editor/src/ui/graphics/sprite_editor_tab/mod.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::Ui;
 
 #[derive(Debug, Clone, Default)]
 pub struct SpriteEditor {}

--- a/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/mod.rs
+++ b/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/mod.rs
@@ -12,7 +12,7 @@ use sheet_list::SheetList;
 use sheet_settings::SheetSettings;
 
 // Externals
-use egui::{TextureId, Ui};
+use eframe::egui::{TextureId, Ui};
 
 use super::PaletteEditor;
 use crate::editor_data::EditorGraphicsData;

--- a/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/palette_preview.rs
+++ b/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/palette_preview.rs
@@ -1,4 +1,4 @@
-use egui::{TextureId, Ui};
+use eframe::egui::{TextureId, Ui};
 
 use crate::{editor_data::EditorPalette, ui::draw_palette_preview};
 

--- a/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/sheet_editor.rs
+++ b/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/sheet_editor.rs
@@ -1,4 +1,6 @@
-use egui::{ColorImage, ImageButton, ScrollArea, TextureHandle, Ui, Vec2};
+use eframe::egui::{
+    self, ColorImage, ImageButton, ScrollArea, TextureFilter, TextureHandle, Ui, Vec2,
+};
 
 use super::palette_to_map;
 use crate::ui::import_many_images_dialog;
@@ -50,14 +52,15 @@ impl SheetEditor {
 
                                 let image = match self.texture_handles.get_mut(index.0 as usize) {
                                     Some(handle) => {
-                                        handle.set(rgb);
+                                        handle.set(rgb, TextureFilter::Nearest);
                                         handle
                                     }
                                     None => {
-                                        self.texture_handles.push(
-                                            ui.ctx()
-                                                .load_texture(format!("sprite_{}", index.0), rgb),
-                                        );
+                                        self.texture_handles.push(ui.ctx().load_texture(
+                                            format!("sprite_{}", index.0),
+                                            rgb,
+                                            TextureFilter::Nearest,
+                                        ));
                                         &mut self.texture_handles[index.0 as usize]
                                     }
                                 };

--- a/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/sheet_list.rs
+++ b/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/sheet_list.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::Ui;
 use gamercade_core::{SpriteSheet, SpriteSheetIndex};
 
 use crate::editor_data::{EditorGraphicsData, EditorSpriteSheet};

--- a/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/sheet_settings.rs
+++ b/gamercade_editor/src/ui/graphics/sprite_sheet_editor_tab/sheet_settings.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 use std::{fmt::Display, str::FromStr};
 
-use egui::{Button, TextEdit, Ui};
+use eframe::egui::{Button, TextEdit, Ui};
 
 use crate::editor_data::EditorSpriteSheet;
 

--- a/gamercade_editor/src/ui/rom_editor.rs
+++ b/gamercade_editor/src/ui/rom_editor.rs
@@ -1,4 +1,4 @@
-use egui::Ui;
+use eframe::egui::{self, Ui};
 use gamercade_core::{FrameRate, Resolution};
 
 use crate::editor_data::EditorRom;


### PR DESCRIPTION
Now that egui supports `TextureFilter::Nearest`, we don't need to do the manual `glutin` `glow` stuff.

This shows severe performance gains especially when related to #36 