### PR TITLE
feat(draw_api): Add `circle_filled`

### DIFF
--- a/gamercade_console/src/api/draw_api.rs
+++ b/gamercade_console/src/api/draw_api.rs
@@ -15,8 +15,8 @@ pub trait DrawApi {
     fn set_pixel(&mut self, graphics_parameters: i32, x: i32, y: i32);
 
     fn circle(&mut self, graphics_parameters: i32, x: i32, y: i32, radius: i32);
-    //TODO
-    // fn circle_filled(&self, x: i32, y: i32, color_index: i32, palette_index: i32);
+
+    fn circle_filled(&mut self, graphics_parameters: i32, x: i32, y: i32, radius: i32);
 
     fn rect(&mut self, graphics_parameters: i32, x: i32, y: i32, width: i32, height: i32);
 
@@ -31,7 +31,7 @@ derive_bind_draw_api! {
     bind_clear_screen,
     bind_set_pixel,
     bind_circle,
-    //bind_circle_filled,
+    bind_circle_filled,
     bind_rect,
     bind_rect_filled,
     bind_line,

--- a/gamercade_console/src/console/bindings/draw_binding.rs
+++ b/gamercade_console/src/console/bindings/draw_binding.rs
@@ -27,7 +27,7 @@ derive_draw_api_binding! {
     set_pixel(graphics_parameters: i32, x: i32, y: i32),
 
     circle(graphics_parameters: i32, x: i32, y: i32, radius: i32),
-    // fn circle_filled(x: i32, y: i32, color_index: i32, palette_index: i32),
+    circle_filled(graphics_parameters: i32, x: i32, y: i32, radius: i32),
 
     rect(
         graphics_parameters: i32,

--- a/gamercade_console/src/console/contexts/draw_context.rs
+++ b/gamercade_console/src/console/contexts/draw_context.rs
@@ -171,19 +171,20 @@ impl DrawApi for DrawContext {
             return;
         }
 
-        let x0 = x as usize;
-        let y0 = y as usize;
-
         let mut f = 1 - radius;
         let mut ddf_x = 0;
         let mut ddf_y = -2 * radius;
+
+        let radius = radius as usize;
+        let x0 = x as usize;
+        let y0 = y as usize;
         let mut x = 0;
         let mut y = radius;
 
-        self.set_pixel_safe(XCord(x0), YCord(y0 + radius as usize), color);
-        self.set_pixel_safe(XCord(x0), YCord(y0 - radius as usize), color);
-        self.set_pixel_safe(XCord(x0 + radius as usize), YCord(y0 as usize), color);
-        self.set_pixel_safe(XCord(x0 - radius as usize), YCord(y0 as usize), color);
+        self.set_pixel_safe(XCord(x0), YCord(y0 + radius), color);
+        self.set_pixel_safe(XCord(x0), YCord(y0 - radius), color);
+        self.set_pixel_safe(XCord(x0 + radius), YCord(y0), color);
+        self.set_pixel_safe(XCord(x0 - radius), YCord(y0), color);
 
         while x < y {
             if f >= 0 {
@@ -195,14 +196,14 @@ impl DrawApi for DrawContext {
             x += 1;
             ddf_x += 2;
             f += ddf_x + 1;
-            self.set_pixel_safe(XCord(x0 + x as usize), YCord(y0 + y as usize), color);
-            self.set_pixel_safe(XCord(x0 - x as usize), YCord(y0 + y as usize), color);
-            self.set_pixel_safe(XCord(x0 + x as usize), YCord(y0 - y as usize), color);
-            self.set_pixel_safe(XCord(x0 - x as usize), YCord(y0 - y as usize), color);
-            self.set_pixel_safe(XCord(x0 + y as usize), YCord(y0 + x as usize), color);
-            self.set_pixel_safe(XCord(x0 - y as usize), YCord(y0 + x as usize), color);
-            self.set_pixel_safe(XCord(x0 + y as usize), YCord(y0 - x as usize), color);
-            self.set_pixel_safe(XCord(x0 - y as usize), YCord(y0 - x as usize), color);
+            self.set_pixel_safe(XCord(x0 + x), YCord(y0 + y), color);
+            self.set_pixel_safe(XCord(x0 - x), YCord(y0 + y), color);
+            self.set_pixel_safe(XCord(x0 + x), YCord(y0 - y), color);
+            self.set_pixel_safe(XCord(x0 - x), YCord(y0 - y), color);
+            self.set_pixel_safe(XCord(x0 + y), YCord(y0 + x), color);
+            self.set_pixel_safe(XCord(x0 - y), YCord(y0 + x), color);
+            self.set_pixel_safe(XCord(x0 + y), YCord(y0 - x), color);
+            self.set_pixel_safe(XCord(x0 - y), YCord(y0 - x), color);
         }
     }
 

--- a/gamercade_console/src/console/contexts/draw_context.rs
+++ b/gamercade_console/src/console/contexts/draw_context.rs
@@ -228,17 +228,16 @@ impl DrawApi for DrawContext {
             return;
         }
 
-        let x0 = x as usize;
-        let y0 = y as usize;
-
         let mut f = 1 - radius;
         let mut ddf_x = 0;
         let mut ddf_y = -2 * radius;
+
+        let x0 = x;
+        let y0 = y;
         let mut x = 0;
         let mut y = radius;
 
-        self.set_pixel_safe(XCord(x0 as usize), YCord(y0 as usize), color);
-
+        self.draw_line_horizontal(x0 - radius, x0 + radius, y0, color);
         while x < y {
             if f >= 0 {
                 y -= 1;
@@ -249,14 +248,10 @@ impl DrawApi for DrawContext {
             x += 1;
             ddf_x += 2;
             f += ddf_x + 1;
-            self.draw_line_horizontal(x0 as i32 - x, x0 as i32 + x, y0 as i32 + y, color);
-            self.draw_line_horizontal(x0 as i32 - x, x0 as i32 + x, y0 as i32 - y, color);
-            self.draw_line_horizontal(x0 as i32 - y, x0 as i32 + y, y0 as i32 + x, color);
-            self.draw_line_horizontal(x0 as i32 - y, x0 as i32 + y, y0 as i32 - x, color);
-            self.draw_line_vertical(x0 as i32 - y, y0 as i32 - x, y0 as i32 + x, color);
-            self.draw_line_vertical(x0 as i32 + y, y0 as i32 - x, y0 as i32 + x, color);
-            self.draw_line_vertical(x0 as i32 - x, y0 as i32 - x, y0 as i32 + x, color);
-            self.draw_line_vertical(x0 as i32 + x, y0 as i32 - x, y0 as i32 + x, color);
+            self.draw_line_horizontal(x0 - x, x0 + x, y0 + y, color);
+            self.draw_line_horizontal(x0 - y, x0 + y, y0 + x, color);
+            self.draw_line_horizontal(x0 - x, x0 + x, y0 - y, color);
+            self.draw_line_horizontal(x0 - y, x0 + y, y0 - x, color);
         }
     }
 }

--- a/gamercade_rs/src/api/draw.rs
+++ b/gamercade_rs/src/api/draw.rs
@@ -26,6 +26,14 @@ pub fn circle(graphics_parameters: GraphicsParameters, x: i32, y: i32, radius: u
     unsafe { raw::circle(gp, x, y, radius as i32) }
 }
 
+/// Draws a filled circle around point (x, y) on the screen with the passed in radius.
+/// Uses palette_index and color_index. A transparent color will still have it's
+/// RGB values used to color the screen.
+pub fn circle_filled(graphics_parameters: GraphicsParameters, x: i32, y: i32, radius: u32) {
+    let gp = graphics_parameters.into();
+    unsafe { raw::circle_filled(gp, x, y, radius as i32) }
+}
+
 /// Draws an empty rectangle with the top left point (x, y) with width and height.
 /// Uses palette_index and color_index. A transparent color will still have it's
 /// RGB values used to color the screen.

--- a/gamercade_rs/src/raw.rs
+++ b/gamercade_rs/src/raw.rs
@@ -35,6 +35,7 @@ extern "C" {
     pub fn clear_screen(graphics_parameters: i32);
     pub fn set_pixel(graphics_parameters: i32, x: i32, y: i32);
     pub fn circle(graphics_parameters: i32, x: i32, y: i32, radius: i32);
+    pub fn circle_filled(graphics_parameters: i32, x: i32, y: i32, radius: i32);
     pub fn rect(graphics_parameters: i32, x: i32, y: i32, width: i32, height: i32);
     pub fn rect_filled(graphics_parameters: i32, x: i32, y: i32, width: i32, height: i32);
     pub fn line(graphics_parameters: i32, x0: i32, y0: i32, x1: i32, y1: i32);


### PR DESCRIPTION
Closes #5.

The main logic for the `circle_filled` was shamelessly borrowed from `circle` function.
There might be room for optimization, but curious to know what would be your take on this.