### PR TITLE
Audio Editor - Songs, Chains, Phrases, Sfx

### DIFF
--- a/gamercade_editor/src/ui/audio/audio_editor.rs
+++ b/gamercade_editor/src/ui/audio/audio_editor.rs
@@ -170,16 +170,17 @@ impl AudioEditor {
         {
             self.oscilloscope.open = false;
         };
-        if ui
-            .selectable_value(
-                &mut self.oscilloscope.mode,
-                OscilloscopeMode::Channels,
-                "Channels",
-            )
-            .clicked()
-        {
-            self.oscilloscope.open = true
-        };
+        // TODO: Add this back in when we have per-channel oscilloscope
+        // if ui
+        //     .selectable_value(
+        //         &mut self.oscilloscope.mode,
+        //         OscilloscopeMode::Channels,
+        //         "Channels",
+        //     )
+        //     .clicked()
+        // {
+        //     self.oscilloscope.open = true
+        // };
         if ui
             .selectable_value(
                 &mut self.oscilloscope.mode,


### PR DESCRIPTION
2nd Pass at Audio Editor. Continuation of #43. This one is more focused around creation of song / BGM data to be played back later. Since instruments are a requirement of songs, we did that first

TODO:
- [ ] Fix instrument list alignment
- [ ] Start/Stop buttons for Playback
- [ ] Phrase Editor UI
- [ ] Chain Editor UI
- [ ] Song Editor UI

Nice To Haves (For Future Reference)
- Ability determine frequency of samples automatically, via FFT? or other algorithm.
- Better / More Flexible Oscilliscope, adjustable for viewing single channels vs entire output etc
- MIDI Integration for Piano Roll
- Clamp instrument, phrase, chain, sfx, song lengths to their maximum values.
- Better piano roll integration when editing fields