### PR TITLE
feat(hex input): added hex input for the colors

### DIFF
--- a/gamercade_editor/src/ui/graphics/palette_editor_tab/color_editor.rs
+++ b/gamercade_editor/src/ui/graphics/palette_editor_tab/color_editor.rs
@@ -1,4 +1,4 @@
-use eframe::egui::{ Checkbox, Color32, Image, Slider, TextEdit, TextureHandle, Ui, Vec2 };
+use eframe::egui::{Checkbox, Color32, Image, Slider, TextEdit, TextureHandle, Ui, Vec2};
 use gamercade_core::Color;
 
 #[derive(Clone, Debug, Default)]
@@ -14,7 +14,7 @@ impl ColorEditor {
         ui: &mut Ui,
         current_color: &mut Color,
         texture_handle: &TextureHandle,
-        index: usize
+        index: usize,
     ) {
         if self.prev_color != *current_color {
             self.preview = *current_color;
@@ -30,14 +30,21 @@ impl ColorEditor {
 
                 ui.label(format!("Color index: {index}"));
 
-                draw_picker(ui, texture_handle, "Current", false, current_color, &mut current_hex);
+                draw_picker(
+                    ui,
+                    texture_handle,
+                    "Current",
+                    false,
+                    current_color,
+                    &mut current_hex,
+                );
                 draw_picker(
                     ui,
                     texture_handle,
                     "Preview",
                     true,
                     &mut self.preview,
-                    &mut self.hex_preview
+                    &mut self.hex_preview,
                 );
 
                 ui.horizontal(|ui| {
@@ -63,7 +70,7 @@ fn draw_picker(
     text: &'static str,
     editable: bool,
     color: &mut Color,
-    hex_color: &mut String
+    hex_color: &mut String,
 ) {
     ui.group(|ui| {
         ui.label(text);
@@ -74,28 +81,43 @@ fn draw_picker(
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
                     ui.label("R");
-                    if ui.add_enabled(editable, Slider::new(&mut color.r, 0..=255)).changed() {
+                    if ui
+                        .add_enabled(editable, Slider::new(&mut color.r, 0..=255))
+                        .changed()
+                    {
                         *hex_color = color.to_hex_string();
                     }
                 });
 
                 ui.horizontal(|ui| {
                     ui.label("G");
-                    if ui.add_enabled(editable, Slider::new(&mut color.g, 0..=255)).changed() {
+                    if ui
+                        .add_enabled(editable, Slider::new(&mut color.g, 0..=255))
+                        .changed()
+                    {
                         *hex_color = color.to_hex_string();
                     }
                 });
 
                 ui.horizontal(|ui| {
                     ui.label("B");
-                    if ui.add_enabled(editable, Slider::new(&mut color.b, 0..=255)).changed() {
+                    if ui
+                        .add_enabled(editable, Slider::new(&mut color.b, 0..=255))
+                        .changed()
+                    {
                         *hex_color = color.to_hex_string();
                     }
                 });
 
                 ui.horizontal(|ui| {
                     ui.label("Hex");
-                    if ui.add_enabled(editable, TextEdit::singleline(hex_color).desired_width(64.0)).changed() {
+                    if ui
+                        .add_enabled(
+                            editable,
+                            TextEdit::singleline(hex_color).desired_width(64.0),
+                        )
+                        .changed()
+                    {
                         let _result = color.update_from_hex_string(hex_color);
                     }
                 });


### PR DESCRIPTION
Issue: https://github.com/gamercade-io/gamercade_console/issues/23

Hey, 

I have picked an old issue and added the hex input. It seems to work great. 

Feel free to ask for any improvement since I am already deep diving into the best practices of rust. 

And by the way great project keep pushing!

<img width="1374" alt="image" src="https://github.com/gamercade-io/gamercade_console/assets/71312948/5336846b-dcd4-489c-bee5-8a4c05ae319e">
